### PR TITLE
Fix base url to deploy to GitHub page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,6 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Technoveltyco // Web Developer</title>
 
-  <base href="/" target="_self">
-
   <!-- Bootstrap CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
   <!-- Bootstrap Icons -->
@@ -30,7 +28,7 @@
   <header class="navbar navbar-expand-lg navbar-dark bg-dark py-0 sticky-top">
 
     <!--navbar brand -->
-    <a href="bootcamp-week3-challenge/" class="navbar-brand text-highlight">
+    <a href="/bootcamp-week3-challenge/" class="navbar-brand text-highlight">
       <h1>Technoveltyco</h1>
     </a>
     <!-- end navbar brand -->


### PR DESCRIPTION
Remove the base tag because the static base URL  value is not compatible between local and production environments. It should be handled dynamically.